### PR TITLE
update refreshTokens

### DIFF
--- a/apps/api/src/auth/auth.resolver.ts
+++ b/apps/api/src/auth/auth.resolver.ts
@@ -1,7 +1,10 @@
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { SignInInput } from './dto/signin.input';
-import { AuthPayload } from './entities/auth-payload.entity';
+import { AuthPayload, RefreshPayload } from './entities/auth-payload.entity';
+import { UseGuards } from '@nestjs/common';
+import { RefreshAuthGuard } from './guards/refresh-auth/refresh-auth.guard';
+import { User } from '@prisma/client';
 
 @Resolver()
 export class AuthResolver {
@@ -11,5 +14,12 @@ export class AuthResolver {
   async signIn(@Args('signInInput') signInInput: SignInInput) {
     const user = await this.authService.validateLocalUser(signInInput);
     return await this.authService.login(user);
+  }
+
+  @UseGuards(RefreshAuthGuard)
+  @Mutation(() => RefreshPayload)
+  async refreshTokens(@Context() context: { req: { user: User } }) {
+    const user = context.req.user;
+    return this.authService.refreshToken(user.id);
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -82,11 +82,9 @@ export class AuthService {
     return currentUser;
   }
 
-  async refreshToken(userId: number, name: string) {
+  async refreshToken(userId: number) {
     const { accessToken, refreshToken } = await this.generateTokens(userId);
     return {
-      id: userId,
-      name: name,
       accessToken,
       refreshToken,
     };

--- a/apps/api/src/auth/entities/auth-payload.entity.ts
+++ b/apps/api/src/auth/entities/auth-payload.entity.ts
@@ -17,3 +17,12 @@ export class AuthPayload {
   @Field()
   refreshToken: string;
 }
+
+@ObjectType()
+export class RefreshPayload {
+  @Field()
+  accessToken: string;
+
+  @Field()
+  refreshToken: string;
+}

--- a/apps/api/src/auth/strategies/refresh-token.strategy.ts
+++ b/apps/api/src/auth/strategies/refresh-token.strategy.ts
@@ -14,7 +14,7 @@ export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh-jwt') {
     private authService: AuthService,
   ) {
     super({
-      jwtFromRequest: ExtractJwt.fromBodyField('refresh'),
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: refreshTokenConfig.secret as string,
       ignoreExpiration: false,
     });

--- a/apps/api/src/graphql/schema.gql
+++ b/apps/api/src/graphql/schema.gql
@@ -18,6 +18,11 @@ type AuthPayload {
   refreshToken: String!
 }
 
+type RefreshPayload {
+  accessToken: String!
+  refreshToken: String!
+}
+
 type Query {
   hello: String!
 }
@@ -25,6 +30,7 @@ type Query {
 type Mutation {
   createUser(createUserInput: CreateUserInput!): User!
   signIn(signInInput: SignInInput!): AuthPayload!
+  refreshTokens: RefreshPayload!
 }
 
 input CreateUserInput {


### PR DESCRIPTION
This pull request introduces a refresh token mechanism to the authentication system, enabling token renewal without requiring reauthentication. Key changes include the addition of a new `RefreshPayload` entity, a `refreshTokens` mutation, and updates to the refresh token strategy for improved security.

### Authentication Enhancements:
* Added a `refreshTokens` mutation in `AuthResolver` to allow users to renew their access tokens using a refresh token. This mutation is protected by the new `RefreshAuthGuard` and returns a `RefreshPayload` object. (`apps/api/src/auth/auth.resolver.ts`, [apps/api/src/auth/auth.resolver.tsR18-R24](diffhunk://#diff-9945cc2d35f3556a88f3717d2ba10d4117adf2ab4d5696a0e498d594c2e2076bR18-R24))
* Introduced a new `RefreshPayload` entity to encapsulate the access token and refresh token in the GraphQL schema. (`apps/api/src/auth/entities/auth-payload.entity.ts`, [[1]](diffhunk://#diff-a78673ce82f4968699dde7f24c673ea3e292bdd5bf635b54eda274f42128f1d1R20-R28); `apps/api/src/graphql/schema.gql`, [[2]](diffhunk://#diff-a52dfe074d6d34f7c67354e8305dea410abd5664933ee903223fa4fb602e3fa0R21-R33)

### Service Updates:
* Simplified the `refreshToken` method in `AuthService` to only require the `userId` parameter, removing unnecessary fields like `name`. (`apps/api/src/auth/auth.service.ts`, [apps/api/src/auth/auth.service.tsL85-L89](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6L85-L89))

### Security Improvements:
* Updated the refresh token strategy to extract the token from the `Authorization` header instead of the request body, aligning with standard security practices. (`apps/api/src/auth/strategies/refresh-token.strategy.ts`, [apps/api/src/auth/strategies/refresh-token.strategy.tsL17-R17](diffhunk://#diff-e8641287f081b216e0cc5ea7fb9a9a7f43f8a7f84f43c3f568f9ec9bc5a61b00L17-R17))